### PR TITLE
Update templates_intro.tex

### DIFF
--- a/latex/templates_intro.tex
+++ b/latex/templates_intro.tex
@@ -23,7 +23,7 @@ Finally, an appendix (\autoref{isexpression}) on the ubiquitous \D{is} expressio
 \section*{Conventions}\label{conventions}
 \addcontentsline{toc}{section}{Conventions}
 
-To make this document more easily readable, I'll use standard coding books conventions, by highlighting parts of the text. Mainly, in this doc:
+To make this document more easily readable, I'll use standard coding book conventions, by highlighting parts of the text. Mainly, in this doc:
 
 \begin{itemize}
 \item D keywords will be marked like this: \D{int}, \D{static if}, \D{\_\_traits}.


### PR DESCRIPTION
I think "book conventions" is more natural English, having both words plural sounds a bit awkward (though meaning is still clear).
