### PR TITLE
Changed StoD to DtoS in Transformer code sample

### DIFF
--- a/D-templates-tutorial.md
+++ b/D-templates-tutorial.md
@@ -289,12 +289,12 @@ Obviously, using templates like this, with their full name, is a pain. The nifty
 module internaldeclarations2;
 import declaration;
 
-alias Transformer!(double, string) StoD;
+alias Transformer!(double, string) DtoS;
 
 void main()
 {
-    auto s = StoD.transform(3.14159);
-    auto m = new StoD.Modificator(1.618); // StoD.Modificator is a class
+    auto s = DtoS.transform(3.14159);
+    auto m = new DtoS.Modificator(1.618); // DtoS.Modificator is a class
                                           // storing a double and a string.
 }
 ```


### PR DESCRIPTION
The instantiated template converts a double to a string, but is called StoD ( string to double ). This change doesn't really change anything, but makes more sense I think.
